### PR TITLE
Remove weird whitespace in 25.2/Dockerfile

### DIFF
--- a/25.2/Dockerfile
+++ b/25.2/Dockerfile
@@ -1,4 +1,4 @@
 from alpine:3.6
 
-# install emacs
-	run apk update && apk add emacs
+# Install emacs
+run apk update && apk add emacs


### PR DESCRIPTION
I also used uppercase `Install` as in the 25.1/Dockerfile