### PR TITLE
Add support for Emacs 26.3

### DIFF
--- a/26.3-cask/Dockerfile
+++ b/26.3-cask/Dockerfile
@@ -1,0 +1,13 @@
+from alpine:3.11
+
+run apk update && apk add \
+	git \
+	curl \
+	python \
+	emacs \
+	openssh \
+	bash \
+	git
+
+run curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
+env PATH="/root/.cask/bin:${PATH}"

--- a/26.3/Dockerfile
+++ b/26.3/Dockerfile
@@ -1,0 +1,4 @@
+from alpine:3.11
+
+# Install emacs
+run apk update && apk add emacs


### PR DESCRIPTION
Seems like alpine 3.11 tracks Emacs 26.3