### PR TITLE
Add support for emacs 27.1

### DIFF
--- a/27.1-cask/Dockerfile
+++ b/27.1-cask/Dockerfile
@@ -1,0 +1,13 @@
+from alpine:3.13
+
+run apk update && apk add \
+	git \
+	curl \
+	python \
+	emacs \
+	openssh \
+	bash \
+	git
+
+run curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
+env PATH="/root/.cask/bin:${PATH}"

--- a/27.1/Dockerfile
+++ b/27.1/Dockerfile
@@ -1,0 +1,4 @@
+from alpine:3.13
+
+# Install emacs
+run apk update && apk add emacs


### PR DESCRIPTION
Alpine 3.13 is not released yet, waiting for that to be released (whenever that happens) before merging.